### PR TITLE
Merge ref attributes

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -15,7 +15,7 @@
          '[adzerk.boot-test :refer :all])
 
 
-(def +version+ "1.0.0")
+(def +version+ "1.0.1")
 (bootlaces! +version+)
 
 (task-options!

--- a/src/reifyhealth/specmonstah/core.clj
+++ b/src/reifyhealth/specmonstah/core.clj
@@ -98,13 +98,15 @@
               refs))
 
 (defn- add-query-term-relations
-  "Unpacks the query DSL, inserting referenced entities. For example,
+  "Recusively unpacks the query DSL, inserting referenced entities. For example,
   if the query includes the term
   
   [::book {:author-id :a1}]
   
   Then this function will insert a copy of 
-  (get-in relations [::author ::template]) at [::author :a1]."
+  (get-in relations [::author ::template]) at [::author :a1].
+
+  Also merges all attributes specified for referenced entities"
   [[ent-type refs] relations]
   (reduce-kv (fn [relations ent-field ref-name]
                (let [field-ref-type (get-in relations [ent-type ::template 0 ent-field 0])
@@ -116,7 +118,9 @@
                                                (assoc-in relations
                                                          [field-ref-type ref-name]
                                                          [(merge-template-refs (first ref-template) (ref-names ref-refs))
-                                                          (merge (second ref-template) ref-attrs)])))
+                                                          (merge (second ref-template)
+                                                                 (get-in relations [field-ref-type ref-name 1])
+                                                                 ref-attrs)])))
                    (assoc-in relations [field-ref-type ref-name] ref-template))))
              relations
              refs))

--- a/test/reifyhealth/specmonstah/core_test.clj
+++ b/test/reifyhealth/specmonstah/core_test.clj
@@ -198,11 +198,18 @@
                       [::author :a1]
                       [::book :b1]]}))
 
-  (is (= (#'sm/gen-tree gen1 template-relations [[::chapter {:book-id [:b1 {} {:author-id "Custom Author Id" :book-name "Nested Query Book Name"}]}]])
+  ;; Test that nested ref attributes get merged. :book-name and
+  ;; :author-id are added in separate refs, but the result has them
+  ;; merged.
+  (is (= (#'sm/gen-tree gen1 template-relations [[::chapter {:book-id [:b1 {} {:book-name "Nested Query Book Name"}]}]
+                                                 [::chapter {:book-id [:b1 {} {:author-id "Custom Author Id"}]}]
+                                                 [::chapter {:book-id [:b1 {} {}]}]])
          {::author {::sm/template {:id 10 :author-name "Fabrizio S."}}
           ::publisher {::sm/template {:id 11 :publisher-name "PublishCo"}}
           ::book {:b1 {:id 12 :book-name "Nested Query Book Name" :author-id "Custom Author Id" :publisher-id 11}}
-          ::sm/query [[::chapter {:id 13 :chapter-name "Chapter 1" :book-id 12}]]
+          ::sm/query [[::chapter {:id 13 :chapter-name "Chapter 1" :book-id 12}]
+                      [::chapter {:id 14 :chapter-name "Chapter 1" :book-id 12}]
+                      [::chapter {:id 15 :chapter-name "Chapter 1" :book-id 12}]]
           ::sm/order [[::author ::sm/template]
                       [::publisher ::sm/template]
                       [::book :b1]]})))

--- a/test/reifyhealth/specmonstah/core_test.clj
+++ b/test/reifyhealth/specmonstah/core_test.clj
@@ -44,7 +44,7 @@
 
 (defn normalize-and-expand
   [query]
-  (let [query (sm/vectorize-query-terms query)]
+  (let [query (#'sm/vectorize-query-terms query)]
     [(#'sm/gen-format-query template-relations query)
      (#'sm/add-query-relations template-relations query)]))
 
@@ -196,4 +196,15 @@
           ::sm/order [[::author ::sm/template]
                       [::publisher ::sm/template]
                       [::author :a1]
+                      [::book :b1]]}))
+
+  (is (= (#'sm/gen-tree gen1 template-relations [[::chapter {:book-id [:b1 {} {:author-id "Custom Author Id" :book-name "Nested Query Book Name"}]}]])
+         {::author {::sm/template {:id 10 :author-name "Fabrizio S."}}
+          ::publisher {::sm/template {:id 11 :publisher-name "PublishCo"}}
+          ::book {:b1 {:id 12 :book-name "Nested Query Book Name" :author-id "Custom Author Id" :publisher-id 11}}
+          ::sm/query [[::chapter {:id 13 :chapter-name "Chapter 1" :book-id 12}]]
+          ::sm/order [[::author ::sm/template]
+                      [::publisher ::sm/template]
                       [::book :b1]]})))
+
+


### PR DESCRIPTION
Fixes annoying behavior where, if you reference an entity in multiple places and wanted to specify that entity's attributes, you have to put the attributes in the last entity reference. If you didn't do that, the attributes you specified would be silently ignored.