### PR TITLE
throw helpful exception specifying a relation that doesn't exist

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -15,7 +15,7 @@
          '[adzerk.boot-test :refer :all])
 
 
-(def +version+ "1.0.1")
+(def +version+ "1.1.0-SNAPSHOT")
 (bootlaces! +version+)
 
 (task-options!

--- a/src/reifyhealth/specmonstah/core.clj
+++ b/src/reifyhealth/specmonstah/core.clj
@@ -111,7 +111,7 @@
   (reduce-kv (fn [relations ent-field ref-name]
                (let [field-ref-type (get-in relations [ent-type ::template 0 ent-field 0])
                      ref-template (get-in relations [field-ref-type ::template])]
-                 (if-not field-ref-type
+                 (when-not field-ref-type
                    (throw (ex-info (str "The relation " ent-field " for " ent-type " does not exist")
                                    {:ent-type ent-type
                                     :ent-field ent-field})))

--- a/src/reifyhealth/specmonstah/core.clj
+++ b/src/reifyhealth/specmonstah/core.clj
@@ -111,6 +111,10 @@
   (reduce-kv (fn [relations ent-field ref-name]
                (let [field-ref-type (get-in relations [ent-type ::template 0 ent-field 0])
                      ref-template (get-in relations [field-ref-type ::template])]
+                 (if-not field-ref-type
+                   (throw (ex-info (str "The relation " ent-field " for " ent-type " does not exist")
+                                   {:ent-type ent-type
+                                    :ent-field ent-field})))
                  (if (vector? ref-name)
                    ;; ref recursively queries its own refs
                    (let [[ref-name ref-refs ref-attrs] ref-name]

--- a/test/reifyhealth/specmonstah/core_test.clj
+++ b/test/reifyhealth/specmonstah/core_test.clj
@@ -189,7 +189,7 @@
                                                [::chapter {:book-id [:b1 {:author-id :a1} {:book-name "Nested Query Book Name"}]}]])
          {::author {:a1 {:id 6 :author-name "Fabrizio S."}
                     ::sm/template {:id 4 :author-name "Fabrizio S."}}
-          ::publisher {::sm/template {:id 5 :publisher-name "PublishCo"}}
+          ::publisher {::sm/template {:id 5 :publisher-name "PublishCo"}}xb
           ::book {:b1 {:id 7 :book-name "Nested Query Book Name" :author-id 6 :publisher-id 5}}
           ::sm/query [[::book {:id 8 :book-name "Custom Book Name 1" :author-id 4 :publisher-id 5}]
                       [::chapter {:id 9 :chapter-name "Chapter 1" :book-id 7}]]
@@ -214,7 +214,7 @@
                       [::publisher ::sm/template]
                       [::book :b1]]})))
 
-(deftest handles-nonexistent-ref
+(deftest handles-nonexistent-relation
   (is (thrown-with-msg?
         clojure.lang.ExceptionInfo
         #"The relation :.*? for :.*? does not exist"

--- a/test/reifyhealth/specmonstah/core_test.clj
+++ b/test/reifyhealth/specmonstah/core_test.clj
@@ -178,15 +178,15 @@
           ::chapter {::sm/template [{:book-id [::book ::sm/template :id]} nil]}})))
 
 (deftest gen-tree
-  (is (= (#'sm/gen-tree gen1 template-relations [::book])
+  (is (= (sm/gen-tree gen1 template-relations [::book])
          {::author {::sm/template {:id 1 :author-name "Fabrizio S."}}
           ::publisher {::sm/template {:id 2 :publisher-name "PublishCo"}}
           ::sm/query [[::book {:id 3 :book-name "The Book" :author-id 1 :publisher-id 2}]]
           ::sm/order [[::author ::sm/template]
                       [::publisher ::sm/template]]}))
 
-  (is (= (#'sm/gen-tree gen1 template-relations [[::book {} {:book-name "Custom Book Name 1"}]
-                                                 [::chapter {:book-id [:b1 {:author-id :a1} {:book-name "Nested Query Book Name"}]}]])
+  (is (= (sm/gen-tree gen1 template-relations [[::book {} {:book-name "Custom Book Name 1"}]
+                                               [::chapter {:book-id [:b1 {:author-id :a1} {:book-name "Nested Query Book Name"}]}]])
          {::author {:a1 {:id 6 :author-name "Fabrizio S."}
                     ::sm/template {:id 4 :author-name "Fabrizio S."}}
           ::publisher {::sm/template {:id 5 :publisher-name "PublishCo"}}
@@ -201,9 +201,9 @@
   ;; Test that nested ref attributes get merged. :book-name and
   ;; :author-id are added in separate refs, but the result has them
   ;; merged.
-  (is (= (#'sm/gen-tree gen1 template-relations [[::chapter {:book-id [:b1 {} {:book-name "Nested Query Book Name"}]}]
-                                                 [::chapter {:book-id [:b1 {} {:author-id "Custom Author Id"}]}]
-                                                 [::chapter {:book-id [:b1 {} {}]}]])
+  (is (= (sm/gen-tree gen1 template-relations [[::chapter {:book-id [:b1 {} {:book-name "Nested Query Book Name"}]}]
+                                               [::chapter {:book-id [:b1 {} {:author-id "Custom Author Id"}]}]
+                                               [::chapter {:book-id [:b1 {} {}]}]])
          {::author {::sm/template {:id 10 :author-name "Fabrizio S."}}
           ::publisher {::sm/template {:id 11 :publisher-name "PublishCo"}}
           ::book {:b1 {:id 12 :book-name "Nested Query Book Name" :author-id "Custom Author Id" :publisher-id 11}}
@@ -214,4 +214,8 @@
                       [::publisher ::sm/template]
                       [::book :b1]]})))
 
-
+(deftest handles-nonexistent-ref
+  (is (thrown-with-msg?
+        clojure.lang.ExceptionInfo
+        #"The relation :.*? for :.*? does not exist"
+        (sm/gen-tree gen1 template-relations [[::chapter {:nonexistent-id :n1}]]))))


### PR DESCRIPTION
You shouldn't be allowed to run queries that refer to relations that don't exist. Previously, an obscure, unhelpful exception would be thrown. This change handles this exception in a way that makes it easy to debug the error.