### PR TITLE
Add boot.properties to quell warning

### DIFF
--- a/boot.properties
+++ b/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+#Fri Jun 02 13:06:39 EDT 2017
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_CLOJURE_VERSION=1.9.0-alpha14
+BOOT_VERSION=2.7.1


### PR DESCRIPTION
Boot currently warns:

Classpath conflict: org.clojure/clojure version 1.8.0 already loaded, NOT
loading version 1.9.0-alpha14

This should eliminate the warning.

Signed-off-by: Christian Romney <christian@reifyhealth.com>