### PR TITLE
fix boot release tasks to create the jar before attempting to push it

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -25,4 +25,4 @@ deployment:
   clojars:
     branch: master
     commands:
-      - boot push-release-without-gpg
+      - boot make push-release-without-gpg


### PR DESCRIPTION
Turns out the exception on CI was because `push-release-without-gpg` was expecting to find a jar file in the target directory. Adding the `make` remedies this by building the jar.