### PR TITLE
[boot][devenv] add profile.boot with task to generate lein project for Cursive users

### DIFF
--- a/profile.boot
+++ b/profile.boot
@@ -1,0 +1,29 @@
+(defn- generate-lein-project-file! [& {:keys [keep-project] :or {keep-project true}}]
+       (require 'clojure.java.io)
+       (let [pfile ((resolve 'clojure.java.io/file) "project.clj")
+             ; Only works when pom options are set using task-options!
+             {:keys [project version]} (:task-options (meta #'boot.task.built-in/pom))
+             prop #(when-let [x (get-env %2)] [%1 x])
+             head (list* 'defproject (or project 'boot-project) (or version "0.0.0-SNAPSHOT")
+                         (concat
+                           (prop :url :url)
+                           (prop :license :license)
+                           (prop :description :description)
+                           [:dependencies (conj (get-env :dependencies)
+                                                ['boot/core "2.6.0" :scope "compile"])
+                            :repositories (get-env :repositories)
+                            :source-paths (vec (concat (get-env :source-paths)
+                                                       (get-env :resource-paths)))]))
+             proj (pp-str head)]
+            (if-not keep-project (.deleteOnExit pfile))
+            (spit pfile proj)))
+
+(deftask lein-generate
+         "Generate a leiningen `project.clj` file.
+          This task generates a leiningen `project.clj` file based on the boot
+          environment configuration, including project name and version (generated
+          if not present), dependencies, and source paths. Additional keys may be added
+          to the generated `project.clj` file by specifying a `:lein` key in the boot
+          environment whose value is a map of keys-value pairs to add to `project.clj`."
+         []
+         (with-pass-thru fs (generate-lein-project-file! :keep-project true)))

--- a/profile.boot
+++ b/profile.boot
@@ -10,7 +10,7 @@
                            (prop :license :license)
                            (prop :description :description)
                            [:dependencies (conj (get-env :dependencies)
-                                                ['boot/core "2.6.0" :scope "compile"])
+                                                ['boot/core "2.7.1" :scope "compile"])
                             :repositories (get-env :repositories)
                             :source-paths (vec (concat (get-env :source-paths)
                                                        (get-env :resource-paths)))]))


### PR DESCRIPTION
In order to support Cursive and other IDEs/plugins which depend on
leiningen's project.clj for fetching dependencies, I followed:
https://github.com/boot-clj/boot/wiki/For-Cursive-Users
And simply copy-pasted the task into a profile.boot file.

Running `boot lein-generate` generates a project.clj, which Cursive
picks up and allows for better developer experience in Intellij.
