### PR TITLE
remove an unused function

### DIFF
--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -8,8 +8,7 @@
             [clojure.test.check.generators :as gen :include-macros true]
             [clojure.string :as str]
             [clojure.set :as set]
-            [clojure.spec.alpha :as s])
-  (:refer-clojure :exclude [>]))
+            [clojure.spec.alpha :as s]))
 
 (declare add-ent)
 

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -551,13 +551,10 @@
                        visit-fns)
                  ents))))
 
-;; Viewing attributes
-(defn >
-  "Get attrs of node's children. Can be used to get all ents of a
-  type."
-  [{:keys [data]} node]
-  (->> (lg/successors data node)
-       (map (:attrs data))))
+
+;; -----------------
+;; views
+;; -----------------
 
 (defn query-ents
   "Get seq of nodes that are explicitly defined in the query"

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -529,11 +529,6 @@
 
 ;; view tests
 
-(deftest test->
-  (is (= (into #{} (sm/> (sm/build-ent-db {:schema td/schema} {:user [[:_] [:_]]}) :user))
-         #{{:type :ent :index 1 :ent-type :user :query-term [:_]}
-           {:type :ent :index 0 :ent-type :user :query-term [:_]}})))
-
 (deftest test-query-ents
   (is (= [:t0]
          (sm/query-ents (sm/build-ent-db {:schema td/schema} {:todo [[1]]}))))


### PR DESCRIPTION
The `>` function was part of a vague notion to provide css-like navigators. That hasn't panned out, and this function hasn't proven to be useful.