### PR TITLE
tests for specific functions should have the prefix 'test-'

### DIFF
--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -561,7 +561,7 @@
       (is (= (lat/attr (:data db) :u0 :custom-attr-key)
              "yaaaaay a key")))))
 
-(deftest related-ents-by-attr
+(deftest test-related-ents-by-attr
   (let [db (sm/build-ent-db {:schema td/schema} {:todo [[1]]
                                                  :project [[1 {:refs {:todo-list-ids [:tl0 :tl1]}}]]})]
     (is (= (sm/related-ents-by-attr db :t0 :todo-list-id)
@@ -674,12 +674,18 @@
                  (lat/add-attr :w0 :ent-type :watch)
                  (lat/add-attr :w0 :t0 :relation-attrs #{:watched-id}))))
 
-(deftest coll-relation-attr
+(deftest test-coll-relation-attr?
   (let [db (sm/build-ent-db {:schema td/schema} {:project [[1]]})]
     (is (sm/coll-relation-attr? db :p0 :todo-list-ids))
     (is (not (sm/coll-relation-attr? db :p0 :created-by-id)))))
 
-(deftest ent-relations
+(deftest test-ents-by-type
+  (is (= {:user #{:u0}
+          :todo-list #{:tl0}
+          :project #{:p0}}
+         (sm/ents-by-type (sm/build-ent-db {:schema td/schema} {:project [[1]]})))))
+
+(deftest test-ent-relations
   (let [db (sm/build-ent-db {:schema td/schema}
                             {:project [[:p0 {:refs {:todo-list-ids 2}}]]
                              :todo    [[1]]})]
@@ -692,7 +698,7 @@
             :todo-list-id  :tl0}
            (sm/ent-relations db :t0)))))
 
-(deftest all-ent-relations
+(deftest test-all-ent-relations
   (is (= {:project   {:p0 {:created-by-id :u0
                            :updated-by-id :u0
                            :todo-list-ids #{:tl0 :tl1}}}
@@ -702,8 +708,8 @@
                       :tl1 {:created-by-id :u0
                             :updated-by-id :u0}}}
          (sm/all-ent-relations
-          (sm/build-ent-db {:schema td/schema}
-                           {:project [[:p0 {:refs {:todo-list-ids 2}}]]})))))
+           (sm/build-ent-db {:schema td/schema}
+                            {:project [[:p0 {:refs {:todo-list-ids 2}}]]})))))
 
 (deftest assert-schema-refs-must-exist
   (is (thrown-with-msg? #?(:clj java.lang.AssertionError

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -679,12 +679,6 @@
     (is (sm/coll-relation-attr? db :p0 :todo-list-ids))
     (is (not (sm/coll-relation-attr? db :p0 :created-by-id)))))
 
-(deftest test-ents-by-type
-  (is (= {:user #{:u0}
-          :todo-list #{:tl0}
-          :project #{:p0}}
-         (sm/ents-by-type (sm/build-ent-db {:schema td/schema} {:project [[1]]})))))
-
 (deftest test-ent-relations
   (let [db (sm/build-ent-db {:schema td/schema}
                             {:project [[:p0 {:refs {:todo-list-ids 2}}]]


### PR DESCRIPTION
if there's a function named `groovy-fn`, and a test named `groovy-fn`, the test should instead be named `test-groovy-fn`. This will help when you're trying to navigate project-wide definitions.