### PR TITLE
ADDED - Support for Omitting Refs & Overwriting Ref Attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ output
 crash.log
 tmp
 gpg.edn
+project.clj
+pom.xml

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -141,9 +141,18 @@
 ;; -----------------
 
 (defn ent-schema
-  "Given an ent node, return the schema of its corresponding type"
+  "Given an ent name, return the schema of its corresponding type"
   [{:keys [schema data]} ent-name]
   (get schema (lat/attr data ent-name :ent-type)))
+
+(defn relation-attrs-with-constraint
+  "Given an ent name, return all relation attributes which include the constraint."
+  [db ent-name constraint]
+  (->> (ent-schema db ent-name)
+       :constraints
+       (medley/filter-vals (fn [attr-constraints] (contains? attr-constraints :coll)))
+       keys
+       set))
 
 (defn query-opts
   [{:keys [data]} ent-name]

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -21,7 +21,8 @@
 (s/def ::ent-count pos-int?)
 (s/def ::prefix keyword?)
 (s/def ::constraint keyword?)
-(s/def ::spec (s/and keyword? namespace))
+(s/def ::spec (s/or :keyword (s/and keyword? namespace)
+                    :spec    s/spec?))
 
 ;; -----------------
 ;; -----------------

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -288,7 +288,7 @@
 (defn validate-related-ents-query
   "Check that the refs value supplied in a query is a collection if the
   relation type is collection, or a keyword if the relation type is
-  unary"
+  unary. If the reference is omit, no further validation is required."
   [{:keys [schema data] :as db} ent-name relation-attr query-term]
   (let [coll-attr?                      (coll-relation-attr? db ent-name relation-attr)
         {:keys [qr-constraint qr-term]} (conformed-query-opts query-term relation-attr)]

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -315,7 +315,7 @@
 (defn related-ents
   "Returns all related ents for an ent's relation-attr"
   [{:keys [schema data] :as db} ent-name relation-attr related-ent-type query-term]
-  (let [{:keys [qr-constraint qr-type qr-term bind] :as q} (conformed-query-opts query-term relation-attr)]
+  (let [{:keys [qr-constraint qr-type qr-term bind]} (conformed-query-opts query-term relation-attr)]
 
     (validate-related-ents-query db ent-name relation-attr query-term)
 

--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -20,8 +20,8 @@
     (assoc gen-data relation-attr relation-val)))
 
 (defn omit-relation?
-  [db ent-name k]
-  (let [{{ref k} :refs} (sm/query-opts db ent-name)]
+  [db ent-name ent-attr-key]
+  (let [{{ref ent-attr-key} :refs} (sm/query-opts db ent-name)]
     (sm/omit? ref)))
 
 (defn reset-relations

--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -31,15 +31,10 @@
   Next, it will remove any dummy ID's generated for an `:omit` relation. The
   updated ent-data map will be returned."
   [db ent-name ent-data]
-  (let [acoll? (->> (sm/ent-schema db ent-name)
-                    :constraints
-                    (medley/filter-vals
-                      (fn [attr-constraints] (contains? attr-constraints :coll)))
-                    keys
-                    set)]
+  (let [coll-attrs (sm/relation-attrs-with-constraint db ent-name :coll)]
     (into {}
-          (comp (map (fn [[k v]] (if (acoll? k) [k []] [k v])))
-                (map (fn [[k v]] (if (omit-relation? db ent-name k) [k nil] [k v]))))
+          (comp (map (fn [[k v]] (if (coll-attrs k) [k []] [k v])))
+                (map (fn [[k v]] (if-not (omit-relation? db ent-name k) [k v]))))
           ent-data)))
 
 (defn spec-gen-generate-ent-val

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -97,6 +97,18 @@
                  
                  (lat/add-attr :tl0 :u0 :relation-attrs #{:created-by-id :updated-by-id}))))
 
+(deftest test-build-ent-db-one-level-relation-with-omit
+  (is-graph= (:data (sm/build-ent-db {:schema td/schema} {:todo-list [[1 {:refs {:created-by-id ::sm/omit
+                                                                                 :updated-by-id ::sm/omit}}]]}))
+             (-> (lg/digraph [:todo-list :tl0])
+
+                 (lat/add-attr :todo-list :type :ent-type)
+                 (lat/add-attr :tl0 :type :ent)
+                 (lat/add-attr :tl0 :index 0)
+                 (lat/add-attr :tl0 :ent-type :todo-list)
+                 (lat/add-attr :tl0 :query-term [1 {:refs {:created-by-id ::sm/omit
+                                                           :updated-by-id ::sm/omit}}]))))
+
 (deftest test-build-ent-db-mult-ents-w-extended-query
   (is-graph= (:data (sm/build-ent-db {:schema td/schema} {:todo-list [[2 {:refs {:created-by-id :bloop :updated-by-id :bloop}}]]}))
              (-> (lg/digraph [:user :bloop]

--- a/test/reifyhealth/specmonstah/spec_gen_test.cljc
+++ b/test/reifyhealth/specmonstah/spec_gen_test.cljc
@@ -71,18 +71,31 @@
     (is (only-has-ents? gen #{:tl0 :tl1 :tl2 :u0 :p0}))))
 
 (deftest test-spec-gen-manual-attr
-  (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo [[:_ {:spec-gen {:todo-title "pet the dog"}}]]})]
-    (is (td/submap? {:u0 {:user-name "Luigi"}
-                     :t0 {:todo-title "pet the dog"}}
-                    gen))
-    (is (ids-present? gen))
-    (is (ids-match? gen
-                    {:tl0 {:created-by-id [:u0 :id]
-                           :updated-by-id [:u0 :id]}
-                     :t0  {:created-by-id [:u0 :id]
-                           :updated-by-id [:u0 :id]
-                           :todo-list-id  [:tl0 :id]}}))
-    (is (only-has-ents? gen #{:tl0 :t0 :u0}))))
+  (testing "Manual attribute setting for non-reference field"
+    (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo [[:_ {:spec-gen {:todo-title "pet the dog"}}]]})]
+      (is (td/submap? {:u0 {:user-name "Luigi"}
+                       :t0 {:todo-title "pet the dog"}}
+                      gen))
+      (is (ids-present? gen))
+      (is (ids-match? gen
+                      {:tl0 {:created-by-id [:u0 :id]
+                             :updated-by-id [:u0 :id]}
+                       :t0  {:created-by-id [:u0 :id]
+                             :updated-by-id [:u0 :id]
+                             :todo-list-id  [:tl0 :id]}}))
+      (is (only-has-ents? gen #{:tl0 :t0 :u0}))))
+  (testing "Manual attribute setting for reference field"
+    (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo [[:_ {:spec-gen {:created-by-id 1}}]]})]
+      (is (td/submap? {:u0 {:user-name "Luigi"}
+                       :t0 {:created-by-id 1}}
+                      gen))
+      (is (ids-present? gen))
+      (is (ids-match? gen
+                      {:tl0 {:created-by-id [:u0 :id]
+                             :updated-by-id [:u0 :id]}
+                       :t0  {:updated-by-id [:u0 :id]
+                             :todo-list-id  [:tl0 :id]}}))
+      (is (only-has-ents? gen #{:tl0 :t0 :u0})))))
 
 (deftest test-spec-gen-omit
   (testing "Ref not created and data is nil when omitted"


### PR DESCRIPTION
Closes #27 
Closes #29 

## Omitting References

```clojure
;; Only generate the todo-list, but not the user
(sg/ent-db-spec-gen-attr 
  {:schema td/schema} 
  {:todo-list [[:_ {:refs {:created-by-id ::sm/omit
                           :updated-by-id ::sm/omit}}]]})

=> {:tl0 {:id 357, :created-by-id nil, :updated-by-id nil}}

;; Generate the todo-list and a user for created-by-id, but omit updated-by-id
(sg/ent-db-spec-gen-attr 
  {:schema td/schema} 
  {:todo-list [[:_ {:refs {:updated-by-id ::sm/omit}}]]})

=> {:tl0 {:id 361, :created-by-id 360, :updated-by-id nil}, :u0 {:id 360, :user-name "Luigi"}}
```

## Overwrite a Reference Attribute
```clojure
;; Don't omit the reference, simply overwrite the generated id
(sg/ent-db-spec-gen-attr 
  {:schema td/schema} 
  {:todo-list [[1 {:spec-gen {:created-by-id 1
                              :updated-by-id 2}}]]})

=> {:tl0 {:id 365, :created-by-id 1, :updated-by-id 2}, :u0 {:id 364, :user-name "Luigi"}}
```