### PR TITLE
Spec gen function for opts

### DIFF
--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -60,10 +60,14 @@
 (defn spec-gen-merge-overwrites
   "Finally, merge any overwrites specified in the schema or query"
   [{:keys [data] :as db} ent-name ent-attr-key]
-  (let [{:keys [spec-gen]} (sm/ent-schema db ent-name)]
-    (merge (lat/attr data ent-name ent-attr-key)
-           spec-gen
-           (ent-attr-key (sm/query-opts db ent-name)))))
+  (let [{:keys [spec-gen]} (sm/ent-schema db ent-name)
+        spec-generated-val (lat/attr data ent-name ent-attr-key)
+        query-opts         (ent-attr-key (sm/query-opts db ent-name))]
+    (cond-> (lat/attr data ent-name ent-attr-key)
+      (fn? spec-gen)    spec-gen
+      (map? spec-gen)   (merge spec-gen)
+      (fn? query-opts)  query-opts
+      (map? query-opts) (merge query-opts))))
 
 (def spec-gen [spec-gen-generate-ent-val
                spec-gen-assoc-relations

--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -63,7 +63,7 @@
   (let [{:keys [spec-gen]} (sm/ent-schema db ent-name)
         spec-generated-val (lat/attr data ent-name ent-attr-key)
         query-opts         (ent-attr-key (sm/query-opts db ent-name))]
-    (cond-> (lat/attr data ent-name ent-attr-key)
+    (cond-> spec-generated-val
       (fn? spec-gen)    spec-gen
       (map? spec-gen)   (merge spec-gen)
       (fn? query-opts)  query-opts


### PR DESCRIPTION
Prior to this change, you could only pass in a map as spec-gen's opts. spec-gen would merge this map with the generated value, allowing you to overwrite whatever was generated by spec-gen. This change allows you to also pass in a function. The function will be applied to whatever was generated by spec-gen, letting you e.g. dissoc a key.

should wait until #51 lands to review and merge