### PR TITLE
Add dummy references for spec-gen

### DIFF
--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -108,6 +108,17 @@
                  (lat/add-attr :tl0 :query-term [1 {:refs {:created-by-id ::sm/omit
                                                            :updated-by-id ::sm/omit}}]))))
 
+(deftest test-add-ents-one-level-relation-with-dummy
+  (is-graph= (:data (sm/add-ents {:schema td/schema} {:todo-list [[1 {:refs {:created-by-id ::sm/dummy
+                                                                             :updated-by-id ::sm/dummy}}]]}))
+             (-> (lg/digraph [:todo-list :tl0])
+                 (lat/add-attr :todo-list :type :ent-type)
+                 (lat/add-attr :tl0 :type :ent)
+                 (lat/add-attr :tl0 :index 0)
+                 (lat/add-attr :tl0 :ent-type :todo-list)
+                 (lat/add-attr :tl0 :query-term [1 {:refs {:created-by-id ::sm/dummy
+                                                           :updated-by-id ::sm/dummy}}]))))
+
 (deftest test-add-ents-mult-ents-w-extended-query
   (is-graph= (:data (sm/add-ents {:schema td/schema} {:todo-list [[2 {:refs {:created-by-id :bloop :updated-by-id :bloop}}]]}))
              (-> (lg/digraph [:user :bloop]

--- a/test/reifyhealth/specmonstah/spec_gen_test.cljc
+++ b/test/reifyhealth/specmonstah/spec_gen_test.cljc
@@ -121,6 +121,30 @@
       (is (ids-present? gen))
       (is (= nil (-> gen :tl0 :updated-by-id))))))
 
+(deftest test-spec-gen-dummy
+  (testing "Ref not created but attr is given a dummy value for dummy references"
+    (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo-list [[:_ {:refs {:created-by-id ::sm/dummy
+                                                                                    :updated-by-id ::sm/dummy}}]]})
+          tl0 (:tl0 gen)]
+      (is (ids-present? gen))
+      (is (only-has-ents? gen #{:tl0}))
+      (is (= #{:id :created-by-id :updated-by-id} (set (keys tl0))))
+      (is (some? (:created-by-id tl0)))
+      (is (some? (:updated-by-id tl0)))))
+
+  (testing "Dummy reference allows overwriting generated value with custom value"
+    (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo-list [[:_ {:refs     {:updated-by-id ::sm/dummy}
+                                                                             :spec-gen {:updated-by-id 42}}]]})]
+      (is (ids-present? gen))
+      (is (= 42 (-> gen :tl0 :updated-by-id)))))
+
+  (testing "Dummy reference allows overwriting generated value with nil"
+    (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo-list [[:_ {:refs     {:updated-by-id ::sm/dummy}
+                                                                             :spec-gen {:updated-by-id nil}}]]})]
+      (is (ids-present? gen))
+      (is (= nil (-> gen :tl0 :updated-by-id))))))
+
+
 (deftest overwriting
   (testing "Overwriting generated value with query map"
     (let [gen (sg/ent-db-spec-gen-attr {:schema td/schema} {:todo-list [[:_ {:spec-gen {:updated-by-id 42}}]]})]

--- a/tutorial/reifyhealth/specmonstah_tutorial/07.clj
+++ b/tutorial/reifyhealth/specmonstah_tutorial/07.clj
@@ -60,3 +60,12 @@
 (ex-03)
 ;; =>
 {:tl0 {:id 2, :name "v"}}
+
+(defn ex-04
+  []
+  (sg/ent-db-spec-gen-attr {:schema schema}
+                           {:topic [[1 {:refs {:owner-id ::sm/dummy}}]]}))
+
+(ex-04)
+;; =>
+{:tl0 {:owner-id 71, :id 2, :name "v"}}


### PR DESCRIPTION
Add the ability to generate non-nil values for references in spec-gen using `:reifyhealth.specmonstah.core/dummy`. 

The use case I have for this is I have a table with a composite key primary key (id and version) and I need to be able to insert values into it that reference other row ids in same table but still generate the ids for ones that do not reference another row.

With this patch I satisfy my use case in the following way:
```clojure
  (require '[clojure.spec.alpha :as s])
  (require '[reifyhealth.specmonstah
             [core :as sm]
             [spec-gen :as sg]])
  (s/def ::id uuid?)
  (s/def ::version int?)
  (s/def ::value string?)
  (s/def ::versioned-datum (s/keys :req-un [::id ::version ::value]))
  (sg/ent-db-spec-gen-attr {:schema
                            {:my-table {:spec      ::versioned-datum
                                        :relations {:id [:my-table :id]}
                                        :prefix    :mt}}}
                           {:my-table [[:first-version
                                        {:refs     {:id ::sm/dummy}
                                         :spec-gen {:version 1}}]
                                       [:second-version
                                        {:refs     {:id :first-version}
                                         :spec-gen {:version 2}}]]})

  =>
  {:first-version
   {:id #uuid "4a010cb7-bdfb-4f64-abfa-bb719eb16ca1",
    :version 1,
    :value "Jt3"},
   :second-version
   {:id #uuid "4a010cb7-bdfb-4f64-abfa-bb719eb16ca1",
    :version 2,
    :value "KA222fJFxdMuvv"}}

```

There might be a better way to solve this, I'm open to ideas.