### PR TITLE
Prepare release 2.1.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2022-10-7
+
+- Added Babashka support
+- Added Relation helpers `wrap-gen-data-visiting-fn` to support other data generation mechanism
+- Moved to deps.edn
+- Fix visiting entities with self references no longer causes an exception
+
 ## [2.0.0] - 2019-11-5
 
 ### New

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Deps
 
 ```clojure
-[reifyhealth/specmonstah "2.0.0"]
+[reifyhealth/specmonstah "2.1.0"]
 ```
 
 ## Purpose
@@ -237,7 +237,7 @@ graph that represents all their ents and their relationships.
 
 You can apply a function to each ent's graph node in topologically
 sorted (topsort) order and associate the return value as a node
-attribute. 
+attribute.
 
 (Topsort means that if a `:post` references a `:user`, then the
 `:user` will be placed before the `:post` in the sort.)

--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,7 @@
          '[adzerk.boot-test :refer :all]
          '[crisptrutski.boot-cljs-test :refer [test-cljs]])
 
-(def +version+ "2.0.0")
+(def +version+ "2.1.0")
 (bootlaces! +version+)
 
 (task-options!

--- a/demo/deps.edn
+++ b/demo/deps.edn
@@ -8,11 +8,11 @@
          thheller/shadow-cljs             {:mvn/version "2.8.52"}
          binaryage/devtools               {:mvn/version "0.9.4"}
          day8.re-frame/re-frame-10x       {:mvn/version "0.4.1"}
-         reifyhealth/specmonstah          {:mvn/version "2.0.0"}
+         reifyhealth/specmonstah          {:mvn/version "2.1.0"}
          org.clojure/test.check           {:mvn/version "0.9.0"}
          aysylu/loom                      {:mvn/version "1.0.2"}
          sweet-tooth/sweet-tooth-frontend {:mvn/version "0.10.2"}}
- 
+
  :aliases
  {:dev  {:extra-deps {cider/cider-nrepl                {:mvn/version "0.21.0"}
                       refactor-nrepl                   {:mvn/version "2.4.0"}}}}}

--- a/examples/short-sweet/deps.edn
+++ b/examples/short-sweet/deps.edn
@@ -1,3 +1,3 @@
 {:deps {org.clojure/clojure     {:mvn/version "1.10.0"}
-        reifyhealth/specmonstah {:mvn/version "2.0.0"}
+        reifyhealth/specmonstah {:mvn/version "2.1.0"}
         org.clojure/test.check  {:mvn/version "0.9.0"}}}


### PR DESCRIPTION
It looks like it's been a while since the last release. @flyingmachine do you have any objections or thoughts to us creating one? 

Here is the current difference: https://github.com/reifyhealth/specmonstah/compare/master...develop

In this PR:
- Version bump
- Update examples/demo
- Update README
- Add CHANGELOG entry