### PR TITLE
Release 2.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,15 @@ jobs:
           name: Check deps
           command: boot show -d
       - run:
-          name: Run tests
+          name: Run clj and cljs tests
           command: boot test-all
+      - run:
+          name: Install bb
+          command: |
+            sudo bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)
+      - run:
+          name: Run bb tests
+          command: bb test
       - run:
           name: Build
           command: boot make  # Validate the namespaces are correct

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pom.xml
 notes.org
 .lein-repl-history
 .cpcache
+cljs-test-runner-out

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2022-10-7
+
+- Added Babashka support
+- Added Relation helpers `wrap-gen-data-visiting-fn` to support other data generation mechanism
+- Moved to deps.edn
+- Fix visiting entities with self references no longer causes an exception
+
 ## [2.0.0] - 2019-11-5
 
 ### New

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,14 @@
+# Development
+
+Testing:
+
+```shell
+clojure -X:test
+clojure -X:test:cljs
+```
+
+Local install:
+
+```shell
+clojure -T:build jar && clojure -T:build install
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Deps
 
 ```clojure
-[reifyhealth/specmonstah "2.0.0"]
+[reifyhealth/specmonstah "2.1.0"]
 ```
 
 ## Purpose
@@ -237,7 +237,7 @@ graph that represents all their ents and their relationships.
 
 You can apply a function to each ent's graph node in topologically
 sorted (topsort) order and associate the return value as a node
-attribute. 
+attribute.
 
 (Topsort means that if a `:post` references a `:user`, then the
 `:user` will be placed before the `:post` in the sort.)

--- a/README.md
+++ b/README.md
@@ -275,3 +275,8 @@ db. The second argument is a map that includes the following keys:
 * `:visit-query-opts`: just looks up the value of `:visit-key` in the
   `:query-opts` map
 * `:schema-opts`: any options set for `:visit-key` in the schema
+
+## TODO
+
+- document `:bind` syntax
+- document `wrap-gen-data-visiting-fn`

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,15 @@
+{:paths ["src" "test"]
+ :deps {aysylu/loom             {:mvn/version "1.0.2"}
+        medley/medley           {:mvn/version "0.8.3"}
+        better-cond/better-cond {:mvn/version "2.0.1-SNAPSHOT"}
+        org.clojure/core.specs.alpha {:mvn/version "0.2.62"}
+        org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                 :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
+ :tasks
+ {test {:extra-paths ["test"]
+        :extra-deps {io.github.cognitect-labs/test-runner
+                     {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                     org.clojure/tools.namespace {:git/url "https://github.com/babashka/tools.namespace"
+                                                  :git/sha "3625153ee66dfcec2ba600851b5b2cbdab8fae6c"}}
+        :requires ([cognitect.test-runner :as tr])
+        :task (apply tr/-main "-d" "test" *command-line-args*)}}}

--- a/build.boot
+++ b/build.boot
@@ -21,7 +21,7 @@
          '[adzerk.boot-test :refer :all]
          '[crisptrutski.boot-cljs-test :refer [test-cljs]])
 
-(def +version+ "2.0.0")
+(def +version+ "2.1.0")
 (bootlaces! +version+)
 
 (task-options!

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,39 @@
+(ns build
+  "specmonstah's build script. inspired by:
+  * https://github.com/seancorfield/honeysql/blob/develop/build.clj
+  * https://github.com/seancorfield/build-clj
+
+  Run tests:
+  clojure -X:test
+  clojure -X:test-cljs
+  For more information, run:
+  clojure -A:deps -T:build help/doc"
+  (:refer-clojure :exclude [test])
+  (:require [clojure.tools.build.api :as b]
+            [org.corfield.build :as bb]))
+
+(def lib 'reifyhealth/specmonstah)
+(def version (format "2.0.1" (b/git-count-revs nil)))
+
+(defn deploy "Deploy the JAR to Clojars"
+  [opts]
+  (-> opts
+      (assoc :lib lib :version version)
+      (bb/deploy)))
+
+
+(defn jar "build a jar"
+  [opts]
+  (-> opts
+      (assoc :lib lib :version version)
+      (bb/clean)
+      (bb/jar)))
+
+(defn install "Install the JAR locally." [opts]
+  (-> opts
+      (assoc :lib lib :version version)
+      (bb/install)))
+
+(defn test "Run basic tests." [opts]
+  (-> opts
+      (bb/run-tests)))

--- a/demo/deps.edn
+++ b/demo/deps.edn
@@ -8,11 +8,11 @@
          thheller/shadow-cljs             {:mvn/version "2.8.52"}
          binaryage/devtools               {:mvn/version "0.9.4"}
          day8.re-frame/re-frame-10x       {:mvn/version "0.4.1"}
-         reifyhealth/specmonstah          {:mvn/version "2.0.0"}
+         reifyhealth/specmonstah          {:mvn/version "2.1.0"}
          org.clojure/test.check           {:mvn/version "0.9.0"}
          aysylu/loom                      {:mvn/version "1.0.2"}
          sweet-tooth/sweet-tooth-frontend {:mvn/version "0.10.2"}}
- 
+
  :aliases
  {:dev  {:extra-deps {cider/cider-nrepl                {:mvn/version "0.21.0"}
                       refactor-nrepl                   {:mvn/version "2.4.0"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,19 +1,24 @@
-;; This file currently exists for easily running clj tests.
-;; To replace build.boot, more work needs to be done e.g.
-;; configure cljs and provide tasks e.g. deploy and testing
 {:paths ["src"]
+
  :deps {aysylu/loom             {:mvn/version "1.0.2"}
         medley/medley           {:mvn/version "0.8.3"}
         better-cond/better-cond {:mvn/version "2.0.1-SNAPSHOT"}
         org.clojure/spec.alpha  {:mvn/version "0.3.218"}}
+
  :aliases
  {:test
   {:extra-paths ["test"]
-   :extra-deps  {org.clojure/test.check  {:mvn/version "0.9.0"}}}
+   :extra-deps  {org.clojure/test.check               {:mvn/version "0.9.0"}
+                 io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "48c3c67"}}
+   :exec-fn     cognitect.test-runner.api/test}
 
-  :runner
-  {:extra-deps {com.cognitect/test-runner
-                {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                 :git/sha "b6b3193fcc42659d7e46ecd1884a228993441182"}}
-   :main-opts  ["-m" "cognitect.test-runner"
-                "-d" "test"]}}}
+  :test-cljs
+  {:extra-paths ["test"]
+   :extra-deps  {org.clojure/test.check  {:mvn/version "0.9.0"}
+                 olical/cljs-test-runner {:mvn/version "3.8.0"}}
+   :exec-fn     cljs-test-runner.main/-main}
+
+  :build
+  {:deps       {io.github.seancorfield/build-clj
+                {:git/tag "v0.6.6" :git/sha "171d5f1"}}
+   :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,19 @@
+;; This file currently exists for easily running clj tests.
+;; To replace build.boot, more work needs to be done e.g.
+;; configure cljs and provide tasks e.g. deploy and testing
+{:paths ["src"]
+ :deps {aysylu/loom             {:mvn/version "1.0.2"}
+        medley/medley           {:mvn/version "0.8.3"}
+        better-cond/better-cond {:mvn/version "2.0.1-SNAPSHOT"}
+        org.clojure/spec.alpha  {:mvn/version "0.3.218"}}
+ :aliases
+ {:test
+  {:extra-paths ["test"]
+   :extra-deps  {org.clojure/test.check  {:mvn/version "0.9.0"}}}
+
+  :runner
+  {:extra-deps {com.cognitect/test-runner
+                {:git/url "https://github.com/cognitect-labs/test-runner.git"
+                 :git/sha "b6b3193fcc42659d7e46ecd1884a228993441182"}}
+   :main-opts  ["-m" "cognitect.test-runner"
+                "-d" "test"]}}}

--- a/examples/short-sweet/deps.edn
+++ b/examples/short-sweet/deps.edn
@@ -1,3 +1,3 @@
 {:deps {org.clojure/clojure     {:mvn/version "1.10.0"}
-        reifyhealth/specmonstah {:mvn/version "2.0.0"}
+        reifyhealth/specmonstah {:mvn/version "2.1.0"}
         org.clojure/test.check  {:mvn/version "0.9.0"}}}

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -666,7 +666,14 @@
 
 (defn topsort-ents
   [{:keys [data]}]
-  (reverse (#?(:bb topsort :default la/topsort) (ld/nodes-filtered-by #(= (lat/attr data % :type) :ent) data))))
+  (->> data
+       lg/edges
+       (filter (fn [[from to]] (= from to)))
+       (apply lg/remove-edges data)
+       (ld/nodes-filtered-by #(= (lat/attr data % :type) :ent))
+       #?(:bb      topsort
+          :default la/topsort)
+       reverse))
 
 (defn required-attrs
   "Returns a map of `{:ent-type #{:required-attr-1 :required-attr-2}}`.

--- a/src/reifyhealth/specmonstah/core.cljc
+++ b/src/reifyhealth/specmonstah/core.cljc
@@ -1,9 +1,9 @@
 (ns reifyhealth.specmonstah.core
-  (:require [loom.alg :as la]
+  (:require #?(:bb  [loom.alg-generic :as lgen]
+               :default [loom.alg :as la])
             [loom.attr :as lat]
             [loom.graph :as lg]
             [loom.derived :as ld]
-            #?(:clj [loom.io :as lio])
             [medley.core :as medley]
             [better-cond.core :as b]
             [clojure.test.check.generators :as gen :include-macros true]
@@ -49,7 +49,7 @@
 
 ;; A relation is the description of how ents of type A reference ents
 ;; of type B. For example, in this:
-;; 
+;;
 ;; {:user {}
 ;;  :todo {:relations {:created-by-id [:user :id]}}}
 ;;
@@ -80,7 +80,7 @@
 ;; relations are monotype relations. example:
 ;;
 ;; {:topic {:relations {:topic-category-id [:topic-category :id]}}}
-;; 
+;;
 ;; `[:topic-category-id :id]` is a monotype relation
 (s/def ::monotype-relation
   (s/cat :ent-type ::ent-type
@@ -120,9 +120,9 @@
 
 ;; the prefix is used for ent auto-generation to uniquely identify
 ;; ents. Given this schema:
-;; 
+;;
 ;; {:user {:prefix :u}}
-;; 
+;;
 ;; the query `{:user [[2]]}` would produce ents with `ent-name` `:u0`
 ;; and `:u1`
 (s/def ::prefix keyword?)
@@ -183,7 +183,7 @@
 
 ;; examples:
 ;; generate 5 of a thing
-;; [[5]] 
+;; [[5]]
 ;;
 ;; generate 1 of a thing, don't generate the ent corresponding to created-by-id:
 ;; [[1 {:refs {:created-by-id ::omit}}]]
@@ -323,7 +323,7 @@
 (defn add-edge-with-id
   "When indicating :ent-a references :ent-b, include a
   `:relation-attrs` graph attribute that includes the attributes via
-  which `:ent-a` references `:ent-b`. 
+  which `:ent-a` references `:ent-b`.
 
   For example, if the `:project` named `:p0` has an `:owner-id` and
   `:updated-by-id` that both reference the `:user` named `:u0`, then
@@ -377,7 +377,7 @@
   (let [coll-attr?                      (coll-relation-attr? db ent-name relation-attr)
         {:keys [qr-constraint qr-term]} (conformed-query-opts query-term relation-attr)]
     (cond (or (nil? qr-constraint) (= :omit qr-constraint)) nil ;; noop
-          
+
           (and coll-attr? (not= qr-constraint :coll))
           (throw (ex-info "Query-relations for coll attrs must be a number or vector"
                           {:spec-data (s/explain-data ::coll-query-relations qr-term)}))
@@ -399,7 +399,7 @@
             (= qr-type :ent-name)   [qr-term]
             :let [bn (get bind related-ent-type)]
             bn   [bn]
-            
+
             :let [has-bound-descendants? (bound-descendants? db bind related-ent-type)
                   uniq?                  (uniq-relation-attr? db ent-name relation-attr)
                   ent-index              (lat/attr data ent-name :index)]
@@ -590,11 +590,11 @@
   (let [diff (set/difference (set (keys query)) (set (keys schema)))]
     (assert (empty? diff)
             (str "The following ent types are in your query but aren't defined in your schema: " diff)))
-  
+
   (throw-invalid-spec "db" ::db db)
   (throw-invalid-spec "query" ::query query)
   ;; end validations
-  
+
   (let [db (init-db db query)]
     (->> (reduce (fn [db ent-type]
                    (if-let [ent-type-query (ent-type query)]
@@ -654,9 +654,28 @@
         relation-attr  (relation-attrs db ent-name referenced-ent)]
     [referenced-ent relation-attr]))
 
+#?(:bb
+    ;; Copied from la/topsort since bb can't load the loom.alg ns
+   (defn topsort
+   "Topological sort of a directed acyclic graph (DAG). Returns nil if
+      g contains any cycles."
+   ([g]
+    (loop [seen #{}
+           result ()
+           [n & ns] (seq (lg/nodes g))]
+      (if-not n
+        result
+        (if (seen n)
+          (recur seen result ns)
+          (when-let [cresult (lgen/topsort-component
+                              (lg/successors g) n seen seen)]
+            (recur (into seen cresult) (concat cresult result) ns))))))
+   ([g start]
+    (lgen/topsort-component (lg/successors g) start))))
+
 (defn topsort-ents
   [{:keys [data]}]
-  (reverse (la/topsort (ld/nodes-filtered-by #(= (lat/attr data % :type) :ent) data))))
+  (reverse (#?(:bb topsort :default la/topsort) (ld/nodes-filtered-by #(= (lat/attr data % :type) :ent) data))))
 
 (defn required-attrs
   "Returns a map of `{:ent-type #{:required-attr-1 :required-attr-2}}`.
@@ -821,8 +840,12 @@
                   (s/map-of ::ent-name
                             (s/map-of ::ent-attr ::ent-name))))
 
-#?(:clj
-   (defn view
-     "View with loom"
-     [{:keys [data]}]
-     (lio/view data)))
+#?(:bb
+   nil
+   :clj
+   (do
+     (require '[loom.io :as lio])
+     (defn view
+       "View with loom"
+       [{:keys [data]}]
+       (lio/view data))))

--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -36,7 +36,7 @@
 (defn assoc-relation
   "Look up related ent's attr value and assoc with parent ent
   attr. `:coll` relations will add value to a vector."
-  [gen-data relation-attr relation-val constraints]  
+  [gen-data relation-attr relation-val constraints]
   (if (contains? (relation-attr constraints) :coll)
     (update gen-data relation-attr #((fnil conj []) % relation-val))
     (assoc gen-data relation-attr relation-val)))

--- a/src/reifyhealth/specmonstah/spec_gen.cljc
+++ b/src/reifyhealth/specmonstah/spec_gen.cljc
@@ -1,80 +1,20 @@
 (ns reifyhealth.specmonstah.spec-gen
-  (:require [clojure.spec.alpha :as s]
-            [clojure.spec.gen.alpha :as gen]
-            [clojure.data :as data]
-            [reifyhealth.specmonstah.core :as sm]))
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.spec.gen.alpha :as gen]
+   [clojure.data :as data]
+   [reifyhealth.specmonstah.core :as sm]))
 
 (def spec-gen-visit-key :spec-gen)
 
-(s/def ::ent-attrs (s/map-of ::sm/ent-attr ::sm/any))
-
-(defn omit-relation?
-  [db ent-name visit-key]
-  (let [{{ref visit-key} :refs} (sm/query-opts db ent-name)]
-    (sm/omit? ref)))
-
-(defn reset-relations
-  "The generated data will generate values agnostic of any constraints that may
-  be present. This function updates values in the generated data to match up
-  with constraints. First, it will remove any dummy ID's for a `:coll` relation.
-  Next, it will remove any dummy ID's generated for an `:omit` relation. The
-  updated ent-data map will be returned."
-  [db ent-name ent-data]
-  (let [coll-attrs (sm/relation-attrs-with-constraint db ent-name :coll)]
-    (into {}
-          (comp (map (fn [[k v]] (if (coll-attrs k) [k []] [k v])))
-                (map (fn [[k v]] (if-not (omit-relation? db ent-name k) [k v]))))
-          ent-data)))
-
-(defn spec-gen-generate-ent-val
-  "First pass function, uses spec to generate a val for every entity"
-  [db {:keys [ent-name]}]
-  (let [{:keys [spec]} (sm/ent-schema db ent-name)]
-    (->> (gen/generate (s/gen spec))
-         (reset-relations db ent-name))))
-
-(defn assoc-relation
-  "Look up related ent's attr value and assoc with parent ent
-  attr. `:coll` relations will add value to a vector."
-  [gen-data relation-attr relation-val constraints]
-  (if (contains? (relation-attr constraints) :coll)
-    (update gen-data relation-attr #((fnil conj []) % relation-val))
-    (assoc gen-data relation-attr relation-val)))
-
-(defn spec-gen-assoc-relations
-  "Next, look up referenced attributes and assign them"
-  [db {:keys [ent-name visit-key visit-val]}]
-  (let [{:keys [constraints]} (sm/ent-schema db ent-name)
-        skip-keys             (:overwritten (meta visit-val))]
-    (->> (sm/referenced-ent-attrs db ent-name)
-         (filter (comp (complement skip-keys) second))
-         (reduce (fn [ent-data [referenced-ent relation-attr]]
-                   (assoc-relation ent-data
-                                   relation-attr
-                                   (get-in (sm/ent-attr db referenced-ent visit-key)
-                                           (:path (sm/query-relation db ent-name relation-attr)))
-                                   constraints))
-                 visit-val))))
-
-(defn spec-gen-merge-overwrites
-  "Finally, merge any overwrites specified in the schema or query"
-  [db {:keys [ent-name visit-val visit-key visit-query-opts schema-opts]}]
-  (let [merged             (cond-> visit-val
-                             (fn? schema-opts)       schema-opts
-                             (map? schema-opts)      (merge schema-opts)
-                             (fn? visit-query-opts)  visit-query-opts
-                             (map? visit-query-opts) (merge visit-query-opts))
-        changed-keys       (->> (data/diff visit-val merged)
-                                (take 2)
-                                (map keys)
-                                (apply into)
-                                (set))]
-    (with-meta merged {:overwritten changed-keys})))
-
-(def spec-gen [spec-gen-generate-ent-val
-               spec-gen-merge-overwrites
-               spec-gen-assoc-relations])
-
+(def spec-gen
+  (sm/wrap-gen-data-visiting-fn
+   (fn [db {:keys [ent-name]}]
+     (-> db
+         (sm/ent-schema ent-name)
+         :spec
+         s/gen
+         gen/generate))))
 
 (defn ent-db-spec-gen
   "Convenience function to build a new db using the spec-gen mapper
@@ -89,3 +29,80 @@
   [db query]
   (-> (ent-db-spec-gen db query)
       (sm/attr-map spec-gen-visit-key)))
+
+
+;; -----------------
+;; deprecated fns
+;; -----------------
+
+;; the functions below have been refactored and move to
+;; reifyhealth.specmonstah.core.
+
+(defn ^:deprecated omit-relation?
+  [db ent-name reference-key]
+  (sm/omit? (get-in (sm/query-opts db ent-name) [:refs reference-key])))
+
+(defn ^:deprecated reset-relations
+  "The generated data will generate values agnostic of any constraints that may
+  be present. This function updates values in the generated data to match up
+  with constraints. First, it will remove any dummy ID's for a `:coll` relation.
+  Next, it will remove any dummy ID's generated for an `:omit` relation. The
+  updated ent-data map will be returned."
+  [db ent-name ent-data]
+  (let [coll-attrs (sm/relation-attrs-with-constraint db ent-name :coll)]
+    (into {}
+          (comp (map (fn [[k v]] (if (coll-attrs k) [k []] [k v])))
+                (map (fn [[k v]] (when-not (omit-relation? db ent-name k) [k v]))))
+          ent-data)))
+
+(defn ^:deprecated spec-gen-generate-ent-val
+  "First pass function, uses spec to generate a val for every entity"
+  [db {:keys [ent-name]}]
+  (let [{:keys [spec]} (sm/ent-schema db ent-name)]
+    (->> (gen/generate (s/gen spec))
+         (reset-relations db ent-name))))
+
+(defn ^:deprecated spec-gen-generate-ent-
+  "First pass function, uses spec to generate a val for every entity"
+  [db {:keys [ent-name]}]
+  (let [{:keys [spec]} (sm/ent-schema db ent-name)]
+    (->> (gen/generate (s/gen spec))
+         (reset-relations db ent-name))))
+
+(defn ^:deprecated assoc-relation
+  "Look up related ent's attr value and assoc with parent ent
+  attr. `:coll` relations will add value to a vector."
+  [gen-data relation-attr relation-val constraints]
+  (if (contains? (relation-attr constraints) :coll)
+    (update gen-data relation-attr #((fnil conj []) % relation-val))
+    (assoc gen-data relation-attr relation-val)))
+
+(defn ^:deprecated spec-gen-assoc-relations
+  "Next, look up referenced attributes and assign them"
+  [db {:keys [ent-name visit-key visit-val]}]
+  (let [{:keys [constraints]} (sm/ent-schema db ent-name)
+        skip-keys             (:overwritten (meta visit-val) #{})]
+    (->> (sm/referenced-ent-attrs db ent-name)
+         (filter (comp (complement skip-keys) second))
+         (reduce (fn [ent-data [referenced-ent relation-attr]]
+                   (assoc-relation ent-data
+                                   relation-attr
+                                   (get-in (sm/ent-attr db referenced-ent visit-key)
+                                           (:path (sm/query-relation db ent-name relation-attr)))
+                                   constraints))
+                 visit-val))))
+
+(defn ^:deprecated spec-gen-merge-overwrites
+  "Merge any overwrites specified in the schema or query"
+  [_db {:keys [visit-val visit-query-opts schema-opts]}]
+  (let [merged       (cond-> visit-val
+                       (fn? schema-opts)       schema-opts
+                       (map? schema-opts)      (merge schema-opts)
+                       (fn? visit-query-opts)  visit-query-opts
+                       (map? visit-query-opts) (merge visit-query-opts))
+        changed-keys (->> (data/diff visit-val merged)
+                          (take 2)
+                          (map keys)
+                          (apply into)
+                          (set))]
+    (with-meta merged {:overwritten changed-keys})))

--- a/test/reifyhealth/specmonstah/.dir-locals.el
+++ b/test/reifyhealth/specmonstah/.dir-locals.el
@@ -1,0 +1,2 @@
+((clojure-mode . ((cider-clojure-cli-aliases . ":test")
+                  (cider-preferred-build-tool . clojure-cli))))

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -6,12 +6,11 @@
             [clojure.test.check.generators :as gen :include-macros true]
             [reifyhealth.specmonstah.test-data :as td]
             [reifyhealth.specmonstah.core :as sm]
-            [reifyhealth.specmonstah.spec-gen :as sg]
             [loom.graph :as lg]
-            [loom.alg :as la]
             [loom.attr :as lat]))
 
 (use-fixtures :each td/test-fixture)
+
 (use-fixtures :once (fn [t] (stest/instrument) (t)))
 
 (defmacro is-graph=

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -67,12 +67,12 @@
                  (lat/add-attr :u0 :index 0)
                  (lat/add-attr :u0 :query-term [3])
                  (lat/add-attr :u0 :ent-type :user)
-                 
+
                  (lat/add-attr :u1 :type :ent)
                  (lat/add-attr :u1 :index 1)
                  (lat/add-attr :u1 :query-term [3])
                  (lat/add-attr :u1 :ent-type :user)
-                 
+
                  (lat/add-attr :u2 :type :ent)
                  (lat/add-attr :u2 :index 2)
                  (lat/add-attr :u2 :query-term [3])
@@ -81,7 +81,7 @@
 (deftest test-add-ents-one-level-relation
   (is-graph= (:data (sm/add-ents {:schema td/schema} {:todo-list [[1]]}))
              (-> (lg/digraph [:user :u0] [:todo-list :tl0] [:tl0 :u0])
-                 
+
                  (lat/add-attr :user :type :ent-type)
                  (lat/add-attr :u0 :type :ent)
                  (lat/add-attr :u0 :index 0)
@@ -93,7 +93,7 @@
                  (lat/add-attr :tl0 :index 0)
                  (lat/add-attr :tl0 :ent-type :todo-list)
                  (lat/add-attr :tl0 :query-term [1])
-                 
+
                  (lat/add-attr :tl0 :u0 :relation-attrs #{:created-by-id :updated-by-id}))))
 
 (deftest test-add-ents-one-level-relation-with-omit
@@ -166,14 +166,14 @@
                    (lat/add-attr :u0 :index 0)
                    (lat/add-attr :u0 :query-term [:_])
                    (lat/add-attr :u0 :ent-type :user)
-                   
+
                    (lat/add-attr :project :type :ent-type)
                    (lat/add-attr :p0 :type :ent)
                    (lat/add-attr :p0 :index 0)
                    (lat/add-attr :p0 :query-term [:_ {:refs {:todo-list-ids 2}}])
                    (lat/add-attr :p0 :ent-type :project)
                    (lat/add-attr :p0 :u0 :relation-attrs #{:created-by-id :updated-by-id})
-                   
+
                    (lat/add-attr :todo-list :type :ent-type)
                    (lat/add-attr :tl0 :type :ent)
                    (lat/add-attr :tl0 :index 0)
@@ -204,14 +204,14 @@
                    (lat/add-attr :u0 :index 0)
                    (lat/add-attr :u0 :query-term [:_])
                    (lat/add-attr :u0 :ent-type :user)
-                   
+
                    (lat/add-attr :project :type :ent-type)
                    (lat/add-attr :p0 :type :ent)
                    (lat/add-attr :p0 :index 0)
                    (lat/add-attr :p0 :query-term [:_ {:refs {:todo-list-ids [:mario :luigi]}}])
                    (lat/add-attr :p0 :ent-type :project)
                    (lat/add-attr :p0 :u0 :relation-attrs #{:created-by-id :updated-by-id})
-                   
+
                    (lat/add-attr :todo-list :type :ent-type)
                    (lat/add-attr :mario :type :ent)
                    (lat/add-attr :mario :index 0)
@@ -253,7 +253,7 @@
                              [:t0 :bloop]
                              [:t0 :tl-bound-t-0]
                              [:tl-bound-t-0 :bloop])
-                 
+
                  (lat/add-attr :user :type :ent-type)
                  (lat/add-attr :bloop :type :ent)
                  (lat/add-attr :bloop :index 0)
@@ -292,7 +292,7 @@
                                [:t2 :bloop]
                                [:t2 :tl-bound-t-0]
                                [:tl-bound-t-0 :bloop])
-                   
+
                    (lat/add-attr :user :type :ent-type)
                    (lat/add-attr :bloop :type :ent)
                    (lat/add-attr :bloop :index 0)
@@ -348,7 +348,7 @@
                                [:todo-list-watch :tlw1]
                                [:tlw1 :bloop]
                                [:tlw1 :tl-bound-tlw-1])
-                   
+
                    (lat/add-attr :user :type :ent-type)
                    (lat/add-attr :bloop :type :ent)
                    (lat/add-attr :bloop :index 0)
@@ -399,7 +399,7 @@
                              [:t-bound-a-0 :bloop]
                              [:t-bound-a-0 :tl-bound-a-0]
                              [:tl-bound-a-0 :bloop])
-                 
+
                  (lat/add-attr :user :type :ent-type)
                  (lat/add-attr :bloop :type :ent)
                  (lat/add-attr :bloop :index 0)
@@ -450,7 +450,7 @@
                  (lat/add-attr :u0 :index 0)
                  (lat/add-attr :u0 :ent-type :user)
                  (lat/add-attr :u0 :query-term [:_])
-                 
+
                  (lat/add-attr :todo-list :type :ent-type)
                  (lat/add-attr :tl0 :type :ent)
                  (lat/add-attr :tl0 :index 0)
@@ -462,7 +462,7 @@
                  (lat/add-attr :tl1 :index 1)
                  (lat/add-attr :tl1 :ent-type :todo-list)
                  (lat/add-attr :tl1 :query-term [:_])
-                 
+
                  (lat/add-attr :todo-list-watch :type :ent-type)
                  (lat/add-attr :tlw0 :type :ent)
                  (lat/add-attr :tlw0 :index 0)
@@ -474,7 +474,7 @@
                  (lat/add-attr :tlw1 :index 1)
                  (lat/add-attr :tlw1 :ent-type :todo-list-watch)
                  (lat/add-attr :tlw1 :query-term [2])
-                 
+
                  (lat/add-attr :tl0 :u0 :relation-attrs #{:updated-by-id :created-by-id})
                  (lat/add-attr :tl1 :u0 :relation-attrs #{:updated-by-id :created-by-id})
 
@@ -540,13 +540,24 @@
                    (lat/add-attr :t0 :query-term [:t0 {:refs {:todo-list-id :tl0}}])
                    (lat/add-attr :t0 :ent-type :todo)
                    (lat/add-attr :t0 :tl0 :relation-attrs #{:todo-list-id})
-                   
+
                    (lat/add-attr :todo-list :type :ent-type)
                    (lat/add-attr :tl0 :type :ent)
                    (lat/add-attr :tl0 :index 0)
                    (lat/add-attr :tl0 :query-term [:tl0 {:refs {:first-todo-id :t0}}])
                    (lat/add-attr :tl0 :ent-type :todo-list)
                    (lat/add-attr :tl0 :t0 :relation-attrs #{:first-todo-id})))))
+
+(deftest test-add-ents-handles-A->self-cycles
+  (testing "Handle cycles where an entity references itself"
+    (is-graph= (:data (sm/add-ents {:schema td/cycle-schema} {:user [[:u0 {:refs {:updated-by-id :u0}}]]}))
+               (-> (lg/digraph [:user :u0] [:u0 :u0])
+                   (lat/add-attr :user :type :ent-type)
+                   (lat/add-attr :u0 :type :ent)
+                   (lat/add-attr :u0 :index 0)
+                   (lat/add-attr :u0 :query-term [:u0 {:refs {:updated-by-id :u0}}])
+                   (lat/add-attr :u0 :ent-type :user)
+                   (lat/add-attr :u0 :u0 :relation-attrs #{:updated-by-id})))))
 
 ;; -----------------
 ;; polymorphism tests
@@ -740,6 +751,30 @@
                                             sm/merge-overwrites
                                             sm/assoc-referenced-vals])
                  (sm/attr-map :test)))))))
+
+(deftest test-visit-self-reference
+  (let [user-gen (fn [query]
+                   (-> (sm/add-ents {:schema td/cycle-schema} query)
+                       (sm/visit-ents-once :gen
+                                           [(let [id (partial swap!
+                                                              (atom 0)
+                                                              inc)]
+                                              (fn [_ _]
+                                                (let [i (id)]
+                                                  {:id i :updated-by-id i})))
+                                            sm/merge-overwrites
+                                            sm/assoc-referenced-vals])
+                       (sm/attr-map :gen)))]
+    (is (= {:u0 {:id 1, :updated-by-id 1}} (user-gen {:user [[1]]}))
+        "only create one entity with self reference")
+    (testing "self reference can be specified explicitly"
+      (let [{:keys [u0 u1]} (user-gen
+                             {:user [[1]
+                                     [1 {:refs {:updated-by-id :u1}}]]})]
+        (is (= (:id u0) (:updated-by-id u0)))
+        (is (= (:id u1) (:updated-by-id u1)))
+        (is (not= (:id u0) (:id u1)))
+        (is (not= (:version u0) (:updated-by-id u1)))))))
 
 ;; -----------------
 ;; view tests

--- a/test/reifyhealth/specmonstah/core_test.cljc
+++ b/test/reifyhealth/specmonstah/core_test.cljc
@@ -1,9 +1,7 @@
 (ns reifyhealth.specmonstah.core-test
   (:require #?(:clj [clojure.test :refer [deftest is are use-fixtures testing]]
                :cljs [cljs.test :include-macros true :refer [deftest is are use-fixtures testing]])
-            [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
-            [clojure.test.check.generators :as gen :include-macros true]
             [reifyhealth.specmonstah.test-data :as td]
             [reifyhealth.specmonstah.core :as sm]
             [loom.graph :as lg]
@@ -110,14 +108,14 @@
                  (lat/add-attr :tl0 :query-term [1 {:refs {:created-by-id ::sm/omit
                                                            :updated-by-id ::sm/omit}}]))))
 
-(deftest testadd-entsb-mult-ents-w-extended-query
+(deftest test-add-ents-mult-ents-w-extended-query
   (is-graph= (:data (sm/add-ents {:schema td/schema} {:todo-list [[2 {:refs {:created-by-id :bloop :updated-by-id :bloop}}]]}))
              (-> (lg/digraph [:user :bloop]
                              [:todo-list :tl0]
                              [:todo-list :tl1]
                              [:tl0 :bloop]
                              [:tl1 :bloop])
-                 
+
                  (lat/add-attr :user :type :ent-type)
                  (lat/add-attr :bloop :type :ent)
                  (lat/add-attr :bloop :index 0)
@@ -156,7 +154,7 @@
                                                             :updated-by-id :owner0}}])
                  (lat/add-attr :tl0 :owner0 :relation-attrs #{:updated-by-id :created-by-id}))))
 
-(deftest testadd-entsb-two-level-coll-relation
+(deftest testadd-ents-two-level-coll-relation
   (testing "can specify how many ents to gen in a coll relationship"
     (is-graph= (:data (strip-db (sm/add-ents {:schema td/schema} {:project [[:_ {:refs {:todo-list-ids 2}}]]})))
                (-> (lg/digraph [:user :u0]
@@ -433,7 +431,7 @@
                  (lat/add-attr :t-bound-a-0 :tl-bound-a-0 :relation-attrs #{:todo-list-id})
 
                  (lat/add-attr :tl-bound-a-0 :bloop :relation-attrs #{:created-by-id :updated-by-id}))))
-=
+
 (deftest test-add-ents-uniq-constraint
   (is-graph= (:data (sm/add-ents {:schema td/schema} {:todo-list-watch [[2]]}))
              (-> (lg/digraph [:user :u0]
@@ -490,6 +488,16 @@
   (is (not (sm/bound-descendants? (sm/init-db {:schema td/schema} {}) {:user :bibbity} :user)))
   (is (not (sm/bound-descendants? (sm/init-db {:schema td/schema} {}) {:attachment :bibbity} :user))))
 
+(deftest test-add-ents-throws-exception-on-invalid-db
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo
+                           :cljs js/Object)
+                        #"db is invalid"
+                        (sm/add-ents {:schema []} {})))
+  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo
+                           :cljs js/Object)
+                        #"query is invalid"
+                        (sm/add-ents {:schema td/schema} {:user [[]]}))))
+
 (deftest queries-can-have-anon-names
   (is (= (:data (sm/add-ents {:schema td/schema} {:user [[:_] [:_]]}))
          (-> (lg/digraph [:user :u0] [:user :u1] )
@@ -503,7 +511,7 @@
              (lat/add-attr :u1 :query-term [:_])
              (lat/add-attr :u1 :ent-type :user)))))
 
-(deftest handles-A->A-cycles
+(deftest test-add-ents-handles-A->A-cycles
   (testing "Handle cycles where two entities of the same type reference each other"
     (is-graph= (:data (sm/add-ents {:schema td/cycle-schema} {:user [[:u0 {:refs {:updated-by-id :u1}}]
                                                                      [:u1 {:refs {:updated-by-id :u0}}]]}))
@@ -521,7 +529,7 @@
                    (lat/add-attr :u1 :ent-type :user)
                    (lat/add-attr :u1 :u0 :relation-attrs #{:updated-by-id})))))
 
-(deftest handles-A->B-cycles
+(deftest test-add-ents-handles-A->B-cycles
   (testing "Handle cycles where two entities of the different types reference each other"
     (is-graph= (:data (sm/add-ents {:schema td/cycle-schema} {:todo      [[:t0 {:refs {:todo-list-id :tl0}}]]
                                                               :todo-list [[:tl0 {:refs {:first-todo-id :t0}}]]}))
@@ -540,58 +548,9 @@
                    (lat/add-attr :tl0 :ent-type :todo-list)
                    (lat/add-attr :tl0 :t0 :relation-attrs #{:first-todo-id})))))
 
-;; view tests
-
-(deftest test-attr-map
-  (let [db (sm/add-ents {:schema td/schema} {:todo [[1]]})]
-    (is (= {:tl0 :todo-list
-            :t0  :todo
-            :u0  :user}
-           (sm/attr-map db :ent-type)))
-    (is (= {:u0  :user}
-           (sm/attr-map db :ent-type [:u0])))))
-
-(deftest test-query-ents
-  (is (= [:t0]
-         (sm/query-ents (sm/add-ents {:schema td/schema} {:todo [[1]]}))))
-
-  (is (= #{:t0 :u0}
-         (set (sm/query-ents (sm/add-ents {:schema td/schema} {:user [[1]]
-                                                               :todo [[1]]}))))))
-
-(deftest test-add-ents-throws-exception-on-invalid-db
-  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo
-                           :cljs js/Object)
-                        #"db is invalid"
-                        (sm/add-ents {:schema []} {})))
-  (is (thrown-with-msg? #?(:clj clojure.lang.ExceptionInfo
-                           :cljs js/Object)
-                        #"query is invalid"
-                        (sm/add-ents {:schema td/schema} {:user [[]]}))))
-
-(deftest updates-node-attrs
-  (let [db (-> (sm/add-ents {:schema td/schema} {:user [[:_]]})
-               (sm/visit-ents-once :custom-attr-key (constantly "yaaaaay a key")))]
-    (is (= (lat/attr (:data db) :u0 :custom-attr-key)
-           "yaaaaay a key"))))
-
-(deftest does-not-override-node-attr
-  (testing "If node already has attr, subsequent invocations of visit-ents-once will not overwrite it"
-    (let [db (-> (sm/add-ents {:schema td/schema} {:user [[:_]]})
-                 (sm/visit-ents-once :custom-attr-key (constantly "yaaaaay a key"))
-                 (sm/visit-ents-once :custom-attr-key (constantly "overwrite!")))]
-      (is (= (lat/attr (:data db) :u0 :custom-attr-key)
-             "yaaaaay a key")))))
-
-(deftest test-related-ents-by-attr
-  (let [db (sm/add-ents {:schema td/schema} {:todo [[1]]
-                                             :project [[1 {:refs {:todo-list-ids [:tl0 :tl1]}}]]})]
-    (is (= (sm/related-ents-by-attr db :t0 :todo-list-id)
-           :tl0))
-    (is (= (sm/related-ents-by-attr db :t0 :created-by-id)
-           :u0))
-    (is (= (sm/related-ents-by-attr db :p0 :todo-list-ids)
-           [:tl0 :tl1]))))
+;; -----------------
+;; polymorphism tests
+;; -----------------
 
 (deftest polymorphic-refs
   (is-graph= (:data (sm/add-ents {:schema td/polymorphic-schema}
@@ -603,7 +562,7 @@
                  (lat/add-attr :tc0 :index 0)
                  (lat/add-attr :tc0 :query-term [:_])
                  (lat/add-attr :tc0 :ent-type :topic-category)
-                 
+
                  (lat/add-attr :watch :type :ent-type)
                  (lat/add-attr :w0 :type :ent)
                  (lat/add-attr :w0 :index 0)
@@ -622,7 +581,7 @@
                  (lat/add-attr :tc0 :index 0)
                  (lat/add-attr :tc0 :query-term [:_])
                  (lat/add-attr :tc0 :ent-type :topic-category)
-                 
+
                  (lat/add-attr :watch :type :ent-type)
                  (lat/add-attr :w0 :type :ent)
                  (lat/add-attr :w0 :index 0)
@@ -653,7 +612,7 @@
                  (lat/add-attr :t0 :query-term [:_])
                  (lat/add-attr :t0 :ent-type :topic)
                  (lat/add-attr :t0 :tc0 :relation-attrs #{:topic-category-id})
-                 
+
                  (lat/add-attr :watch :type :ent-type)
                  (lat/add-attr :w0 :type :ent)
                  (lat/add-attr :w0 :index 0)
@@ -686,7 +645,7 @@
                  (lat/add-attr :t0 :query-term [:_ {:bind {:topic-category :tc100}}])
                  (lat/add-attr :t0 :ent-type :topic)
                  (lat/add-attr :t0 :tc100 :relation-attrs #{:topic-category-id})
-                 
+
                  (lat/add-attr :watch :type :ent-type)
                  (lat/add-attr :w0 :type :ent)
                  (lat/add-attr :w0 :index 0)
@@ -695,6 +654,104 @@
                                                    :ref-types {:watched-id :topic}}])
                  (lat/add-attr :w0 :ent-type :watch)
                  (lat/add-attr :w0 :t0 :relation-attrs #{:watched-id}))))
+
+;; -----------------
+;; visiting tests
+;; -----------------
+
+(deftest test-related-ents-by-attr
+  (let [db (sm/add-ents {:schema td/schema} {:todo [[1]]
+                                             :project [[1 {:refs {:todo-list-ids [:tl0 :tl1]}}]]})]
+    (is (= (sm/related-ents-by-attr db :t0 :todo-list-id)
+           :tl0))
+    (is (= (sm/related-ents-by-attr db :t0 :created-by-id)
+           :u0))
+    (is (= (sm/related-ents-by-attr db :p0 :todo-list-ids)
+           [:tl0 :tl1]))))
+
+(deftest test-attr-map
+  (let [db (sm/add-ents {:schema td/schema} {:todo [[1]]})]
+    (is (= {:tl0 :todo-list
+            :t0  :todo
+            :u0  :user}
+           (sm/attr-map db :ent-type)))
+    (is (= {:u0  :user}
+           (sm/attr-map db :ent-type [:u0])))))
+
+
+(deftest visit-ents-once-updates-node-attrs
+  (let [db (-> (sm/add-ents {:schema td/schema} {:user [[:_]]})
+               (sm/visit-ents-once :custom-attr-key (constantly "yaaaaay a key")))]
+    (is (= (lat/attr (:data db) :u0 :custom-attr-key)
+           "yaaaaay a key"))))
+
+(deftest visit-ents-once-does-not-override-node-attr
+  (testing "If node already has attr, subsequent invocations of visit-ents-once will not overwrite it"
+    (let [db (-> (sm/add-ents {:schema td/schema} {:user [[:_]]})
+                 (sm/visit-ents-once :custom-attr-key (constantly "yaaaaay a key"))
+                 (sm/visit-ents-once :custom-attr-key (constantly "overwrite!")))]
+      (is (= (lat/attr (:data db) :u0 :custom-attr-key)
+             "yaaaaay a key")))))
+
+(deftest test-relation-attrs
+  (is (= #{:todo-list-id}
+         (-> (sm/add-ents {:schema td/schema} {:todo [[1]]})
+             (sm/relation-attrs :t0 :tl0)))))
+
+(deftest test-assoc-referenced-vals
+  (let [gen-id (fn [db {:keys [ent-name] :as v}]
+                 {:id (str ent-name "-id")})]
+    (testing "without custom refs"
+      (is (= {:u0  {:id ":u0-id"}
+              :tl0 {:id            ":tl0-id"
+                    :created-by-id ":u0-id"
+                    :updated-by-id ":u0-id"}
+              :t0  {:id            ":t0-id"
+                    :todo-list-id  ":tl0-id"
+                    :created-by-id ":u0-id"
+                    :updated-by-id ":u0-id"}}
+             (-> (sm/add-ents {:schema td/schema} {:todo [[1]]})
+                 (sm/visit-ents-once :test [gen-id sm/assoc-referenced-vals])
+                 (sm/attr-map :test)))))
+
+    (testing "with custom refs"
+      (is (= {:custom-user {:id ":custom-user-id"}
+              :tl0         {:id            ":tl0-id"
+                            :created-by-id ":custom-user-id"
+                            :updated-by-id ":custom-user-id"}}
+             (-> (sm/add-ents
+                  {:schema td/schema}
+                  {:todo-list [[1 {:refs {:created-by-id :custom-user
+                                          :updated-by-id :custom-user}}]]})
+                 (sm/visit-ents-once :test [gen-id sm/assoc-referenced-vals])
+                 (sm/attr-map :test)))))
+
+    (testing "with overwrites"
+      (is (= {:custom-user {:id ":overwritten-id"}
+              :tl0         {:id            ":tl0-id"
+                            :created-by-id ":overwritten-id"
+                            :updated-by-id ":overwritten-id"}}
+             (-> (sm/add-ents
+                  {:schema td/schema}
+                  {:user      [[:custom-user {:test {:id ":overwritten-id"}}]]
+                   :todo-list [[1 {:refs {:created-by-id :custom-user
+                                          :updated-by-id :custom-user}}]]})
+                 (sm/visit-ents-once :test [gen-id
+                                            sm/merge-overwrites
+                                            sm/assoc-referenced-vals])
+                 (sm/attr-map :test)))))))
+
+;; -----------------
+;; view tests
+;; -----------------
+
+(deftest test-query-ents
+  (is (= [:t0]
+         (sm/query-ents (sm/add-ents {:schema td/schema} {:todo [[1]]}))))
+
+  (is (= #{:t0 :u0}
+         (set (sm/query-ents (sm/add-ents {:schema td/schema} {:user [[1]]
+                                                               :todo [[1]]}))))))
 
 (deftest test-coll-relation-attr?
   (let [db (sm/add-ents {:schema td/schema} {:project [[1]]})]
@@ -745,6 +802,10 @@
                              :updated-by-id :u0
                              :todo-list-ids #{:tl0 :tl1}}}}
            (sm/all-ent-relations db [:p0])))))
+
+;; -----------------
+;; validation
+;; -----------------
 
 (deftest assert-schema-refs-must-exist
   (is (thrown-with-msg? #?(:clj java.lang.AssertionError

--- a/tutorial/reifyhealth/specmonstah_tutorial/01.clj
+++ b/tutorial/reifyhealth/specmonstah_tutorial/01.clj
@@ -20,15 +20,15 @@
   (ex-01)
 
   ;; produces this:
-  {:schema {:user {:prefix :u}}
-   :data {:nodeset #{:u1 :u0 :u2 :user}
-          :adj {:user #{:u1 :u0 :u2}}
-          :in {:u0 #{:user} :u1 #{:user} :u2 #{:user}}
-          :attrs {:user {:type :ent-type}
-                  :u0 {:type :ent :index 0 :ent-type :user :query-term [3]}
-                  :u1 {:type :ent :index 1 :ent-type :user :query-term [3]}
-                  :u2 {:type :ent :index 2 :ent-type :user :query-term [3]}}}
-   :queries ({:user [[3]]})
+  {:schema         {:user {:prefix :u}}
+   :data           {:nodeset #{:u1 :u0 :u2 :user}
+                    :adj     {:user #{:u1 :u0 :u2}}
+                    :in      {:u0 #{:user} :u1 #{:user} :u2 #{:user}}
+                    :attrs   {:user {:type :ent-type}
+                              :u0   {:type :ent :index 0 :ent-type :user :query-term [3]}
+                              :u1   {:type :ent :index 1 :ent-type :user :query-term [3]}
+                              :u2   {:type :ent :index 2 :ent-type :user :query-term [3]}}}
+   :queries        [{:user [[3]]}]
    :relation-graph {:nodeset #{:user} :adj {} :in {}}
-   :types #{:user}
-   :ref-ents []})
+   :types          #{:user}
+   :ref-ents       []})


### PR DESCRIPTION
- Added Babashka support
- Added Relation helpers `wrap-gen-data-visiting-fn` to support other data generation mechanisms
- Moved to deps.edn
- Fix visiting entities with self references no longer causes an exception